### PR TITLE
Python 3.6 support

### DIFF
--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -12,8 +12,9 @@ COPY jenkins/default-user.groovy /usr/share/jenkins/ref/init.groovy.d/
 
 ARG goVersion=1.10.3
 
-RUN apt-get update && apt-get install -y vim curl sudo libtool autoconf make unzip rsync gcc autogen shtool pkg-config lsb-release python python-dev python-pip python-setuptools groff less libxml-xpath-perl zip \
-python3.5 python3-dev python3-pip build-essential libssl-dev libffi-dev && curl https://bootstrap.pypa.io/get-pip.py | python && pip install --upgrade awscli && apt-get clean && pip install virtualenv && /usr/bin/easy_install virtualenv && \
+RUN echo "deb http://ftp.fr.debian.org/debian testing main" >> /etc/apt/sources.list && apt-get update && apt-get install -y vim curl sudo libtool autoconf make unzip rsync gcc autogen shtool pkg-config lsb-release python python-dev python-pip python-setuptools groff less libxml-xpath-perl zip \
+python3.6 python3-dev python3-pip python3.6-venv build-essential libssl-dev libffi-dev python-virtualenv && ln -sf /usr/bin/python2.7 /usr/bin/python && ln -sf /usr/bin/python3.6 /usr/bin/python3 && \
+curl https://bootstrap.pypa.io/get-pip.py | python && pip install --upgrade awscli && apt-get clean && \
 wget -O /opt/apache-maven-3.5.2-bin.tar.gz https://archive.apache.org/dist/maven/maven-3/3.5.2/binaries/apache-maven-3.5.2-bin.tar.gz && \
 tar xzvf /opt/apache-maven-3.5.2-bin.tar.gz -C  /opt && export PATH=$PATH:/opt/apache-maven-3.5.2/bin >> /etc/profile.d/maven.sh && ln -sf /opt/apache-maven-3.5.2/bin/mvn /usr/bin/mvn && \
 curl -sL https://deb.nodesource.com/setup_8.x | bash && apt-get install -y nodejs && npm install  -global serverless@1.30 @angular/cli@1.7.3 jshint && \


### PR DESCRIPTION
Jenkins docker file has been updated to support Python 3.6

Note: As a part of ECS story, docker files has been moved from installer to Jazz-content